### PR TITLE
Log level change for zipkin-collector

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,6 +1,7 @@
 FROM itszero/zipkin-base
 MAINTAINER Zero Cho "http://itsze.ro"
 
+ADD collector-cassandra.scala /zipkin/zipkin-collector-service/config/collector-cassandra.scala
 ADD run.sh /usr/local/bin/run
 ENTRYPOINT ["/usr/local/bin/run"]
 

--- a/collector/collector-cassandra.scala
+++ b/collector/collector-cassandra.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.twitter.zipkin.builder.Scribe
+import com.twitter.zipkin.cassandra
+import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
+import com.twitter.zipkin.storage.Store
+
+val keyspaceBuilder = cassandra.Keyspace.static(nodes = Set("localhost"))
+val cassandraBuilder = Store.Builder(
+  cassandra.StorageBuilder(keyspaceBuilder),
+  cassandra.IndexBuilder(keyspaceBuilder),
+  cassandra.AggregatesBuilder(keyspaceBuilder)
+)
+
+
+val loggerFactory = new LoggerFactory(
+            node = "",
+            level = Some(Level.INFO),
+            handlers = List(ConsoleHandler())
+            )
+
+
+CollectorServiceBuilder(Scribe.Interface(categories = Set("zipkin")))
+  .writeTo(cassandraBuilder)
+  .copy(serverBuilder = ZipkinServerBuilder(9410, 9900).loggers(List(loggerFactory))) 

--- a/collector/collector-cassandra.scala
+++ b/collector/collector-cassandra.scala
@@ -17,6 +17,11 @@ import com.twitter.zipkin.builder.Scribe
 import com.twitter.zipkin.cassandra
 import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
 import com.twitter.zipkin.storage.Store
+import com.twitter.logging.LoggerFactory
+import com.twitter.logging.LoggerFactory
+import com.twitter.logging.Level
+import com.twitter.logging.ConsoleHandler
+import com.twitter.zipkin.builder.ZipkinServerBuilder
 
 val keyspaceBuilder = cassandra.Keyspace.static(nodes = Set("localhost"))
 val cassandraBuilder = Store.Builder(


### PR DESCRIPTION
I provided a new collector-cassandra.scala config file that sets the log level to INFO.
By default the log level was set to DEBUG which means that every span submitted to the collector was being logged.  This slows down the collector and generates a huge log.

I guess INFO is good enough. You get some feedback when the collector is started but you don't get lots of irrelevant log entries. Changing it to another log level is also straightforward. The level is defined in collector-cassandra.scala 